### PR TITLE
Add new rpc 'subtensor_epoch'

### DIFF
--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -46,7 +46,7 @@ impl SubstrateCli for Cli {
 
     fn load_spec(&self, id: &str) -> Result<Box<dyn sc_service::ChainSpec>, String> {
         Ok(match id {
-            "local" => Box::new(chain_spec::localnet::localnet_config()?),
+            "dev" => Box::new(chain_spec::localnet::localnet_config()?),
             "finney" => Box::new(chain_spec::finney::finney_mainnet_config()?),
             "" | "test_finney" => Box::new(chain_spec::testnet::finney_testnet_config()?),
             path => Box::new(chain_spec::ChainSpec::from_json_file(

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -46,7 +46,7 @@ impl SubstrateCli for Cli {
 
     fn load_spec(&self, id: &str) -> Result<Box<dyn sc_service::ChainSpec>, String> {
         Ok(match id {
-            "dev" => Box::new(chain_spec::localnet::localnet_config()?),
+            "local" => Box::new(chain_spec::localnet::localnet_config()?),
             "finney" => Box::new(chain_spec::finney::finney_mainnet_config()?),
             "" | "test_finney" => Box::new(chain_spec::testnet::finney_testnet_config()?),
             path => Box::new(chain_spec::ChainSpec::from_json_file(

--- a/node/src/rpc.rs
+++ b/node/src/rpc.rs
@@ -60,6 +60,7 @@ where
     C::Api: subtensor_custom_rpc_runtime_api::NeuronInfoRuntimeApi<Block>,
     C::Api: subtensor_custom_rpc_runtime_api::SubnetInfoRuntimeApi<Block>,
     C::Api: subtensor_custom_rpc_runtime_api::SubnetRegistrationRuntimeApi<Block>,
+    C::Api: subtensor_custom_rpc_runtime_api::SubtensorRuntimeApi<Block, AccountId>,
     B: sc_client_api::Backend<Block> + Send + Sync + 'static,
     P: TransactionPool + 'static,
 {

--- a/pallets/subtensor/Cargo.toml
+++ b/pallets/subtensor/Cargo.toml
@@ -33,7 +33,7 @@ serde_with = { workspace = true, features = ["macros"] }
 sp-runtime = { workspace = true }
 sp-std = { workspace = true }
 log = { workspace = true }
-substrate-fixed = { workspace = true }
+substrate-fixed = { workspace = true, features = ["serde"] }
 pallet-transaction-payment = { workspace = true }
 pallet-utility = { workspace = true }
 ndarray = { workspace = true }

--- a/pallets/subtensor/runtime-api/src/lib.rs
+++ b/pallets/subtensor/runtime-api/src/lib.rs
@@ -1,6 +1,8 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 extern crate alloc;
 use alloc::vec::Vec;
+use frame_support::pallet_prelude::Decode;
+use pallet_subtensor::EpochResponse;
 
 // Here we declare the runtime API. It is implemented it the `impl` block in
 // src/neuron_info.rs, src/subnet_info.rs, and src/delegate_info.rs
@@ -31,5 +33,9 @@ sp_api::decl_runtime_apis! {
 
     pub trait SubnetRegistrationRuntimeApi {
         fn get_network_registration_cost() -> u64;
+    }
+
+    pub trait SubtensorRuntimeApi<AccountId: Decode> {
+         fn get_epoch_info(netuid: u16, is_incentive: Option<bool>) -> EpochResponse<AccountId>;
     }
 }

--- a/pallets/subtensor/src/block_step.rs
+++ b/pallets/subtensor/src/block_step.rs
@@ -180,7 +180,11 @@ impl<T: Config> Pallet<T> {
 
             // --- 8. Run the epoch mechanism and return emission tuples for hotkeys in the network.
             let emission_tuples_this_block: Vec<(T::AccountId, u64, u64)> =
-                Self::epoch(netuid, emission_to_drain);
+                match Self::epoch(netuid, None) {
+                    EpochResponse::Emissions(data) => data,
+                    EpochResponse::IncentiveData(_) => Vec::new(),
+                };
+
             log::debug!(
                 "netuid_i: {:?} emission_to_drain: {:?} ",
                 netuid,

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -19,6 +19,7 @@ use codec::{Decode, Encode};
 use frame_support::sp_runtime::transaction_validity::InvalidTransaction;
 use frame_support::sp_runtime::transaction_validity::ValidTransaction;
 use scale_info::TypeInfo;
+use serde::{Deserialize, Serialize};
 use sp_runtime::{
     traits::{DispatchInfoOf, Dispatchable, PostDispatchInfoOf, SignedExtension},
     transaction_validity::{TransactionValidity, TransactionValidityError},
@@ -2235,6 +2236,15 @@ pub enum CallType {
     Other,
 }
 
+/************************************************************
+    Epoch Info types definition
+************************************************************/
+#[derive(Debug, PartialEq, Encode, Decode, TypeInfo, Clone, Serialize, Deserialize)]
+pub enum EpochResponse<AccountId> {
+    Emissions(Vec<(AccountId, u64, u64)>),
+    IncentiveData(Vec<I32F32>),
+}
+
 #[derive(Encode, Decode, Clone, Eq, PartialEq, TypeInfo)]
 pub struct SubtensorSignedExtension<T: Config + Send + Sync + TypeInfo>(pub PhantomData<T>);
 
@@ -2468,6 +2478,7 @@ use sp_std::vec;
 // used not 25 lines below
 #[allow(unused)]
 use sp_std::vec::Vec;
+use substrate_fixed::types::I32F32;
 
 /// Trait for managing a membership pallet instance in the runtime
 pub trait MemberManagement<AccountId> {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -24,6 +24,7 @@ use pallet_grandpa::{
     fg_primitives, AuthorityId as GrandpaId, AuthorityList as GrandpaAuthorityList,
 };
 use pallet_registry::CanRegisterIdentity;
+use pallet_subtensor::EpochResponse;
 use scale_info::TypeInfo;
 use smallvec::smallvec;
 use sp_api::impl_runtime_apis;
@@ -1675,6 +1676,12 @@ impl_runtime_apis! {
     impl subtensor_custom_rpc_runtime_api::SubnetRegistrationRuntimeApi<Block> for Runtime {
         fn get_network_registration_cost() -> u64 {
             SubtensorModule::get_network_lock_cost()
+        }
+    }
+
+    impl subtensor_custom_rpc_runtime_api::SubtensorRuntimeApi<Block, AccountId> for Runtime {
+        fn get_epoch_info(netuid: u16, is_incentive: Option<bool>) -> EpochResponse<AccountId> {
+            SubtensorModule::epoch(netuid, is_incentive)
         }
     }
 }


### PR DESCRIPTION
- Make an optional Bool argument with default=False called “incentive” in the epoch parameters that, if set to “True”, will return the incentive storage value as Vec&lt;I32F32&gt; instead of the emission tuples
 - cargo clippy and fmt